### PR TITLE
Display error message when something goes wrong in the BE

### DIFF
--- a/frontend/src/api/chess.js
+++ b/frontend/src/api/chess.js
@@ -1,5 +1,5 @@
 import { Method } from './api';
-import { request } from './request';
+import { requestWithErrorToast } from './request';
 
 const ChessEndpoint = {
   EVALUATE_MOVE: '/evaluate_move',
@@ -7,6 +7,14 @@ const ChessEndpoint = {
   ANSWER_QUESTION: '/answer_question',
   GET_BOT_MOVE: '/get_bot_move',
   GET_BEST_MOVE: '/get_best_move',
+};
+
+const errorMessages = {
+  EVALUATE_MOVE: 'An error occurred while evaluating the move.',
+  MOVE_SUGGESTION_WITH_EVALUATION: 'An error occurred while getting the move suggestion.',
+  ANSWER_QUESTION: 'An error occurred while answering the question.',
+  GET_BOT_MOVE: 'An error occurred while getting the bot move.',
+  GET_BEST_MOVE: 'An error occurred while getting the best move.',
 };
 
 /**
@@ -20,7 +28,13 @@ const ChessEndpoint = {
  *  or rejects with an error message.
  */
 export const evaluateMove = async (fen, move) =>
-  request(ChessEndpoint.EVALUATE_MOVE, Method.POST, { fen, move });
+  requestWithErrorToast(
+    ChessEndpoint.EVALUATE_MOVE,
+    Method.POST,
+    { fen, move },
+    {},
+    errorMessages.EVALUATE_MOVE
+  );
 
 /**
  * Gets a suggested move along with its evaluation for a given board position.
@@ -33,7 +47,13 @@ export const evaluateMove = async (fen, move) =>
  *  or rejects with an error message.
  */
 export const getMoveSuggestionWithEvaluation = async (fen) =>
-  request(ChessEndpoint.MOVE_SUGGESTION_WITH_EVALUATION, Method.POST, { fen });
+  requestWithErrorToast(
+    ChessEndpoint.MOVE_SUGGESTION_WITH_EVALUATION,
+    Method.POST,
+    { fen },
+    {},
+    errorMessages.MOVE_SUGGESTION_WITH_EVALUATION
+  );
 
 /**
  * Answers a question about a given chess board position.
@@ -45,7 +65,13 @@ export const getMoveSuggestionWithEvaluation = async (fen) =>
  *  or rejects with an error message.
  */
 export const answerChessQuestion = async (fen, question) =>
-  request(ChessEndpoint.ANSWER_QUESTION, Method.POST, { fen, question });
+  requestWithErrorToast(
+    ChessEndpoint.ANSWER_QUESTION,
+    Method.POST,
+    { fen, question },
+    {},
+    errorMessages.ANSWER_QUESTION
+  );
 
 /**
  * Gets the bot's move for a given board position.
@@ -57,7 +83,13 @@ export const answerChessQuestion = async (fen, question) =>
  *  or rejects with an error message.
  */
 export const getBotMove = async (fen, skill_level) =>
-  request(ChessEndpoint.GET_BOT_MOVE, Method.POST, { fen, skill_level });
+  requestWithErrorToast(
+    ChessEndpoint.GET_BOT_MOVE,
+    Method.POST,
+    { fen, skill_level },
+    {},
+    errorMessages.GET_BOT_MOVE
+  );
 
 /**
  * Gets the best move for a given board position.
@@ -68,4 +100,10 @@ export const getBotMove = async (fen, skill_level) =>
  *  or rejects with an error message.
  */
 export const getBestMove = async (fen) =>
-  request(ChessEndpoint.GET_BEST_MOVE, Method.POST, { fen });
+  requestWithErrorToast(
+    ChessEndpoint.GET_BEST_MOVE,
+    Method.POST,
+    { fen },
+    {},
+    errorMessages.GET_BEST_MOVE
+  );

--- a/frontend/src/api/request.js
+++ b/frontend/src/api/request.js
@@ -1,10 +1,10 @@
+import { toast } from 'react-hot-toast';
+
 const buildURL = (baseURL, path, params) => {
   const url = new URL(path, baseURL);
 
   // Add query parameters if any are provided
-  Object.keys(params).forEach((key) =>
-    url.searchParams.append(key, params[key])
-  );
+  Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));
 
   return url.toString();
 };
@@ -24,8 +24,43 @@ export async function request(path, method, body, params = {}) {
   return window.fetch(buildURL(endpoint, path, params), {
     method: method,
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify(body, (_, value) => value || undefined),
   });
+}
+
+/**
+ * Sends an HTTP request and displays an error toast if the request fails.
+ * The information revealed to the end user is limited to what they need to know.
+ *
+ * @param {string} path - The URL of the wanted resource.
+ * @param {string} method - The HTTP method.
+ * @param {Object} body - The request body.
+ * @param {Object} params - The query parameters.
+ * @param {string} [customErrorMessage] - Optional custom error message to display in the toast.
+ *
+ * @returns {Promise<Response>} - A promise with the response.
+ */
+export async function requestWithErrorToast(path, method, body, params = {}, customErrorMessage) {
+  try {
+    const response = await request(path, method, body, params);
+    console.log(response);
+
+    if (!response.ok) {
+      const message = customErrorMessage || 'An error occurred while processing your request.';
+      toast.error(message);
+    }
+
+    return response;
+  } catch (error) {
+    // Display a generic error message if the request fails,
+    // e.g., due to a network issue or a server error (most likely
+    // due to the server being down).
+    const message =
+      'An error occurred while processing your request. The server might be down or there could be a network issue.';
+    toast.error(message);
+
+    throw error;
+  }
 }

--- a/frontend/src/pages/ChessPage/ChessPage.jsx
+++ b/frontend/src/pages/ChessPage/ChessPage.jsx
@@ -1,6 +1,5 @@
 import { Box } from '@mui/material';
 import { useState } from 'react';
-import toast from 'react-hot-toast';
 import { api } from '../../api/api';
 import { useChat } from '../../hooks/useChat';
 import { useChess } from '../../hooks/useChess';
@@ -27,7 +26,11 @@ export const ChessPage = () => {
   const chess = useChess({
     onPlayerMove: (move, prevFen, currFen) => {
       onPlayerMove(formatUciMove(move), prevFen);
-      updateHistory(move, currFen, config.fullControlMode ? (move['color'] === 'w' ? 'user' : 'bot') : 'user');
+      updateHistory(
+        move,
+        currFen,
+        config.fullControlMode ? (move['color'] === 'w' ? 'user' : 'bot') : 'user'
+      );
     },
     onBotMove: (move, _, currFen) => {
       updateHistory(move, currFen, 'bot');
@@ -58,7 +61,6 @@ export const ChessPage = () => {
       modifyText(`You played ${move}. ${data.feedback}`);
     } catch (error) {
       console.error(error);
-      toast.error('An error occurred while evaluating the move.');
 
       modifyText('An error occurred while evaluating the move.');
     }
@@ -82,7 +84,6 @@ export const ChessPage = () => {
       addArrow(parseArrow(data.suggested_move));
     } catch (error) {
       console.error(error);
-      toast.error('An error occurred while suggesting a move.');
 
       modifyText('An error occurred while suggesting a move.');
     }
@@ -106,7 +107,6 @@ export const ChessPage = () => {
       addResponseFunc(data.answer);
     } catch (error) {
       console.error(error);
-      toast.error('An error occurred while waiting for an answer.');
 
       addResponseFunc('An error occurred while waiting for an answer.');
     }


### PR DESCRIPTION
Added a wrapper around the custom `request` function, with kinda limited customization to show a toast on an fetch error. We could use the error codes as defined in the backend to show more fine grained information, but considering the end user isn't responsible for the actual inputs they don't need to be informed of the error details. This is of course easy for us to retrieve for debugging.